### PR TITLE
Keep cstdbool Header Behind cpp Macros

### DIFF
--- a/src/include/internal/host/nvshmemi_mem_transport.hpp
+++ b/src/include/internal/host/nvshmemi_mem_transport.hpp
@@ -8,7 +8,9 @@
 #define NVSHMEMI_MEM_TRANSPORT_HPP
 
 #include <cstdlib>
-#include <cstdbool>
+#if defined(HAVE_STDBOOL_H) && (__cplusplus < 201703L)
+# include <cstdbool>
+#endif
 #include <climits>
 #include <memory>
 #include <map>

--- a/src/include/internal/host/nvshmemi_symmetric_heap.hpp
+++ b/src/include/internal/host/nvshmemi_symmetric_heap.hpp
@@ -9,7 +9,10 @@
 
 #include <climits>
 #include <cstdlib>
-#include <cstdbool>
+#if defined(HAVE_STDBOOL_H) && (__cplusplus < 201703L)
+# include <cstdbool>
+#endif
+
 #include <cuda.h>
 #include <memory>
 #include <tuple>


### PR DESCRIPTION
When compiling NVSHMEM using GCC 15.2.1 and CUDA 13.0 (nvcc release 13.0, V13.0.88), I get the following warning:
```sh
...
/usr/include/c++/15.2.1/cstdbool:50:6: warning: #warning "<cstdbool> is deprecated in C++17, remove the #include" [-Wcpp]
   50 | #    warning "<cstdbool> is deprecated in C++17, remove the #include"
      |      ^~~~~
...
```
This PR fixes the warning by putting `cstdbool` behind a preprocessor macro, in files that  include it. `cstdbool` was deprecated in C++17 and removed in C++20 [^1].

[^1]: https://en.cppreference.com/w/cpp/header/cstdbool.html