### PR TITLE
transport: Revert Proxy Progress Model Optimization

### DIFF
--- a/src/host/proxy/proxy.cpp
+++ b/src/host/proxy/proxy.cpp
@@ -1425,7 +1425,7 @@ void progress_transports(proxy_state_t *proxy_state) {
 
         if (tcurr->host_ops.progress == NULL) continue;
 
-        status = tcurr->host_ops.progress(tcurr, 1);
+        status = tcurr->host_ops.progress(tcurr);
         NVSHMEMI_NZ_ERROR_JMP(status, NVSHMEMX_ERROR_INTERNAL, out,
                               "transport %d progress failed \n", i);
     }

--- a/src/include/internal/host_transport/transport.h
+++ b/src/include/internal/host_transport/transport.h
@@ -141,7 +141,7 @@ struct nvshmem_transport_host_ops {
                               struct nvshmem_transport *transport);
     int (*finalize)(struct nvshmem_transport *transport);
     int (*show_info)(struct nvshmem_transport *transport, int style);
-    int (*progress)(struct nvshmem_transport *transport, int is_proxy);
+    int (*progress)(struct nvshmem_transport *transport);
 
     rma_handle rma;
     amo_handle amo;

--- a/src/modules/transport/common/transport_ib_common.cpp
+++ b/src/modules/transport/common/transport_ib_common.cpp
@@ -205,7 +205,7 @@ int nvshmemt_ib_common_check_poll_avail(nvshmem_transport_t tcurr, nvshmemt_ib_c
     /* poll until space becomes available in local send qp */
     while (((common_ep->head_op_id - common_ep->tail_op_id) > outstanding_count)) {
         /* *second argument is a noop for now. */
-        status = ib_state->ib_transport_ftable->progress(tcurr, true);
+        status = ib_state->ib_transport_ftable->progress(tcurr);
         NVSHMEMI_NZ_ERROR_JMP(status, NVSHMEMX_ERROR_INTERNAL, out,
                               "progress_send failed, outstanding_count: %d\n", outstanding_count);
     }

--- a/src/modules/transport/common/transport_ib_common.h
+++ b/src/modules/transport/common/transport_ib_common.h
@@ -84,7 +84,7 @@ struct nvshmemt_ib_common_ftable {
                          nvshmemt_ib_common_ep_ptr_t ep);
     int (*ep_connect)(nvshmemt_ib_common_ep_ptr_t ep,
                       struct nvshmemt_ib_common_ep_handle *ep_handle);
-    int (*progress)(nvshmem_transport_t tcurr, int is_proxy);
+    int (*progress)(nvshmem_transport_t tcurr);
     int (*progress_recv)(nvshmem_transport_t tcurr, nvshmemt_ib_wait_predicate_t wait_predicate);
 };
 

--- a/src/modules/transport/ibdevx/ibdevx.cpp
+++ b/src/modules/transport/ibdevx/ibdevx.cpp
@@ -976,7 +976,7 @@ out:
     return status;
 }
 
-int nvshmemt_ibdevx_progress(nvshmem_transport_t t, int is_proxy) {
+int nvshmemt_ibdevx_progress(nvshmem_transport_t t) {
     int status = 0;
     nvshmemt_ib_common_state_t ibdevx_state = (nvshmemt_ib_common_state_t)t->state;
 

--- a/src/modules/transport/ibgda/ibgda.cpp
+++ b/src/modules/transport/ibgda/ibgda.cpp
@@ -608,7 +608,7 @@ out:
     return NVSHMEMX_SUCCESS;
 }
 
-int nvshmemt_ibgda_progress(nvshmem_transport_t t, int is_proxy) {
+int nvshmemt_ibgda_progress(nvshmem_transport_t t) {
     int status = 0;
     status = ibgda_dci_progress(t);
     if (status) return status;

--- a/src/modules/transport/ibrc/ibrc.cpp
+++ b/src/modules/transport/ibrc/ibrc.cpp
@@ -1091,7 +1091,7 @@ out:
     return status;
 }
 
-int nvshmemt_ibrc_progress(nvshmem_transport_t t, int is_proxy) {
+int nvshmemt_ibrc_progress(nvshmem_transport_t t) {
     int status = 0;
     nvshmemt_ib_common_state_t ibrc_state = (nvshmemt_ib_common_state_t)t->state;
 

--- a/src/modules/transport/ucx/ucx.cpp
+++ b/src/modules/transport/ucx/ucx.cpp
@@ -53,7 +53,7 @@ static uint64_t nvshmemt_g_bogus_bounce_buffer = 0;
 static bool use_gdrcopy = 0;
 static bool use_local_atomics = 0;
 
-int nvshmemt_ucx_progress(nvshmem_transport_t transport, int is_proxy);
+int nvshmemt_ucx_progress(nvshmem_transport_t transport);
 
 static nvshmemt_ucx_mem_handle_info_t *get_mem_handle_info(nvshmem_transport_t transport,
                                                            transport_ucx_state_t *ucx_state,
@@ -1033,11 +1033,11 @@ int nvshmemt_ucx_quiet(struct nvshmem_transport *tcurr, int pe, int qp_index) {
     if (use_gdrcopy) {
         if (qp_index != NVSHMEMX_QP_HOST) {
             while (nvshmemt_ucx_submitted_proxy_atomics > nvshmemt_ucx_completed_proxy_atomics) {
-                nvshmemt_ucx_progress(tcurr, true);
+                nvshmemt_ucx_progress(tcurr);
             }
         } else {
             while (nvshmemt_ucx_submitted_host_atomics > nvshmemt_ucx_completed_host_atomics) {
-                nvshmemt_ucx_progress(tcurr, false);
+                nvshmemt_ucx_progress(tcurr);
             }
         }
     }
@@ -1065,7 +1065,7 @@ int nvshmemt_ucx_quiet(struct nvshmem_transport *tcurr, int pe, int qp_index) {
     return 0;
 }
 
-int nvshmemt_ucx_progress(nvshmem_transport_t transport, int is_proxy) {
+int nvshmemt_ucx_progress(nvshmem_transport_t transport) {
     transport_ucx_state_t *ucx_state = (transport_ucx_state_t *)transport->state;
 
     ucp_worker_progress(ucx_state->worker_context);


### PR DESCRIPTION
This commit reverts:

6238b3d9 transport/libfabric: Optimize progress based on is_proxy
e5b7601a transport: Add is_proxy argument to progress()

Although these changes are required for peak performance of the libfabric host proxy transport, Nvidia's functional testing showed that thse changes are causing regressions in some cases.  Revert while root cause is being investigated.