### PR TITLE
cmake: Fix conflicting optimization flags in debug builds

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -257,9 +257,10 @@ macro(nvshmem_library_set_base_config LIBNAME)
 
   target_compile_options(${LIBNAME}
     INTERFACE $<$<AND:$<COMPILE_LANGUAGE:CUDA>,$<BOOL:${NVSHMEM_VERBOSE}>>:-Xptxas -v>
-    PRIVATE $<IF:$<CONFIG:Debug>,-O0;-g;,-O3>
+    PRIVATE $<IF:$<CONFIG:debug>,-O0;-g,-O3>
     $<$<AND:$<BOOL:${NVSHMEM_VERBOSE}>,$<COMPILE_LANGUAGE:CUDA>>:-Xptxas -v>
-    $<IF:$<AND:$<COMPILE_LANGUAGE:CUDA>,$<CONFIG:Debug>>,-O0;-g;-G;,-O3>
+    $<$<AND:$<COMPILE_LANGUAGE:CUDA>,$<CONFIG:debug>>:-O0;-g;-G>
+    $<$<AND:$<COMPILE_LANGUAGE:CUDA>,$<CONFIG:release>>:-O3>
     $<IF:$<STREQUAL:${CMAKE_HOST_SYSTEM_PROCESSOR},"x86_64">,-msse,>
     $<$<AND:$<COMPILE_LANGUAGE:CUDA>,$<BOOL:${NVCC_THREADS}>>:-t4>
   )

--- a/src/device/CMakeLists.txt
+++ b/src/device/CMakeLists.txt
@@ -139,9 +139,10 @@ macro(nvshmem_library_set_base_config LIBNAME)
 
   target_compile_options(${LIBNAME}
     INTERFACE $<$<AND:$<COMPILE_LANGUAGE:CUDA>,$<BOOL:${NVSHMEM_VERBOSE}>>:-Xptxas -v>
-    PRIVATE $<IF:$<CONFIG:Debug>,-O0;-g;,-O3>
+    PRIVATE $<IF:$<CONFIG:debug>,-O0;-g,-O3>
     $<$<AND:$<BOOL:${NVSHMEM_VERBOSE}>,$<COMPILE_LANGUAGE:CUDA>>:-Xptxas -v>
-    $<IF:$<AND:$<COMPILE_LANGUAGE:CUDA>,$<CONFIG:Debug>>,-O0;-g;-G;,-O3>
+    $<$<AND:$<COMPILE_LANGUAGE:CUDA>,$<CONFIG:debug>>:-O0;-g;-G>
+    $<$<AND:$<COMPILE_LANGUAGE:CUDA>,$<CONFIG:release>>:-O3>
     $<IF:$<STREQUAL:${CMAKE_HOST_SYSTEM_PROCESSOR},"x86_64">,-msse,>
     $<$<AND:$<COMPILE_LANGUAGE:CUDA>,$<BOOL:${NVCC_THREADS}>>:-t4>
   )


### PR DESCRIPTION
- Change CONFIG:Debug to CONFIG:debug for case sensitivity
- Remove trailing semicolons in flag lists
- Replace `$<IF:...>` with mutually exclusive `$<$<condition>:...>` for CUDA flags to avoid false branch evaluation on C++ files

Fixes debug builds incorrectly getting both -O0 and -O3 flags.

On Devel:
```
> cd /home/szegel/Nvshmem && rm -rf build && mkdir build && cd build && cmake .. -DNVSHMEM_BUILD_PYTHON_LIB=0 -DNVSHMEM_DEBUG=ON -DNVSHMEM_DEVEL=ON > /dev/null 2>&1 && grep "CXX_FLAGS" /home/szegel/Nvshmem/build/src/CMakeFiles/nvshmem_transport_libfabric.dir/flags.make
CXX_FLAGS = -g -std=gnu++11 -fPIC -O0 -g -O3 -Werror -Wall -Wextra -Wno-unused-function -Wno-unused-parameter -Wno-missing-field-initializers


>  cd /home/szegel/Nvshmem && rm -rf build && mkdir build && cd build && cmake .. -DNVSHMEM_BUILD_PYTHON_LIB=0 -DNVSHMEM_DEVEL=ON > /dev/null 2>&1 && grep "CXX_FLAGS" /home/szegel/Nvshmem/build/src/CMakeFiles/nvshmem_transport_libfabric.dir/flags.make
CXX_FLAGS = -O3 -DNDEBUG -std=gnu++11 -fPIC -O3 -Werror -Wall -Wextra -Wno-unused-function -Wno-unused-parameter -Wno-missing-field-initializers
```

With this PR (no `-O0 -g -O3 ` in debug build):
```
>  cd /home/szegel/Nvshmem && rm -rf build && mkdir build && cd build && cmake .. -DNVSHMEM_BUILD_PYTHON_LIB=0 -DNVSHMEM_DEBUG=ON -DNVSHMEM_DEVEL=ON > /dev/null 2>&1 && grep "CXX_FLAGS" /home/szegel/Nvshmem/build/src/CMakeFiles/nvshmem_transport_libfabric.dir/flags.make
CXX_FLAGS = -g -std=gnu++11 -fPIC -O0 -g -Werror -Wall -Wextra -Wno-unused-function -Wno-unused-parameter -Wno-missing-field-initializers


> cd /home/szegel/Nvshmem && rm -rf build && mkdir build && cd build && cmake .. -DNVSHMEM_BUILD_PYTHON_LIB=0 -DNVSHMEM_DEBUG=OFF -DNVSHMEM_DEVEL=ON > /dev/null 2>&1 && grep "CXX_FLAGS" /home/szegel/Nvshmem/build/src/CMakeFiles/nvshmem_transport_libfabric.dir/flags.make
CXX_FLAGS = -O3 -DNDEBUG -std=gnu++11 -fPIC -O3 -Werror -Wall -Wextra -Wno-unused-function -Wno-unused-parameter -Wno-missing-field-initializers
```