### PR TITLE
Fix Initialization Hang On Unordered Networks

### DIFF
--- a/src/host/proxy/proxy.cpp
+++ b/src/host/proxy/proxy.cpp
@@ -1310,8 +1310,12 @@ inline void progress_channels(proxy_state_t *proxy_state) {
                         NVSHMEMI_NZ_EXIT(status, "error in process_channel_inline<char>\n");
                         break;
                     case NVSHMEMI_OP_FENCE:
-                    case NVSHMEMI_OP_FENCE_QP:
                         TRACE(NVSHMEM_PROXY, "host proxy: received FENCE \n");
+                        status = process_channel_fence(proxy_state, ch);
+                        NVSHMEMI_NZ_EXIT(status, "error in process_channel_fence\n");
+                        break;
+                    case NVSHMEMI_OP_FENCE_QP:
+                        TRACE(NVSHMEM_PROXY, "host proxy: received QP FENCE \n");
                         status = process_channel_qp_fence(proxy_state, ch);
                         NVSHMEMI_NZ_EXIT(status, "error in process_channel_qp_fence\n");
                         break;

--- a/src/host/team/team_internal_cuda.cu
+++ b/src/host/team/team_internal_cuda.cu
@@ -75,6 +75,8 @@ __device__ void nvshmemi_team_creation_state_barrier(
                                          remote_pe);
     }
 
+    nvshmemi_transfer_fence<nvshmemi_threadgroup_thread>(NVSHMEMX_PE_ALL, NULL, 1);
+
     do {
         for (int i = 0; i < myteam->size; i++) {
             int global_pe_index = myteam->pe_mapping[i];

--- a/src/include/non_abi/device/coll/barrier.cuh
+++ b/src/include/non_abi/device/coll/barrier.cuh
@@ -51,6 +51,8 @@ __device__ NVSHMEMI_STATIC NVSHMEMI_DEVICE_ALWAYS_INLINE void sync_dissem_pow2_t
                                               counter[0], to_nbr);
         }
 
+        nvshmemi_transfer_fence<nvshmemi_threadgroup_thread>(NVSHMEMX_PE_ALL, NULL, 1);
+
         /* wait for neighbors notification */
         for (int j = myIdx + 1; j <= k - 1; j += groupSize) {
             shift = j << phase_num;
@@ -106,6 +108,8 @@ __device__ NVSHMEMI_STATIC NVSHMEMI_DEVICE_ALWAYS_INLINE void sync_dissem_thread
                                               counter[0], to_nbr);
         }
 
+        nvshmemi_transfer_fence<nvshmemi_threadgroup_thread>(NVSHMEMX_PE_ALL, NULL, 1);
+
         /* wait for neighbors notification */
         for (int j = myIdx + 1; j <= k - 1; j += groupSize) {
             shift = j * pow_k;
@@ -156,6 +160,8 @@ __device__ NVSHMEMI_STATIC NVSHMEMI_DEVICE_ALWAYS_INLINE void sync_dissem_thread
             nvshmemi_signal_for_barrier<long>(((long *)sync_arr + nvshmemi_device_state_d.mype),
                                               counter[0], to_nbr);
         }
+
+        nvshmemi_transfer_fence<nvshmemi_threadgroup_thread>(NVSHMEMX_PE_ALL, NULL, 1);
 
         /* wait for neighbors notification */
         for (int j = myIdx + 1; j <= k - 1; j += groupSize) {

--- a/src/include/non_abi/device/coll/reduce.cuh
+++ b/src/include/non_abi/device/coll/reduce.cuh
@@ -1079,6 +1079,7 @@ __device__ NVSHMEMI_STATIC NVSHMEMI_DEVICE_ALWAYS_INLINE void gpu_rdxn_recexch_t
             nvshmemi_fence<nvshmemi_threadgroup_thread>();
             nvshmemi_signal_for_barrier<long>((long *)(pSync + rank), sync_counter[0],
                                               step1_sendto);
+            nvshmemi_transfer_fence<nvshmemi_threadgroup_thread>(NVSHMEMX_PE_ALL, NULL, 1);
         }
     } else if (step1_nrecvs != 0) {
         for (int i = 0; i < step1_nrecvs; i += 1) {
@@ -1120,6 +1121,8 @@ __device__ NVSHMEMI_STATIC NVSHMEMI_DEVICE_ALWAYS_INLINE void gpu_rdxn_recexch_t
                                                   step2_nbrs[phase][i]);
             }
 
+            nvshmemi_transfer_fence<nvshmemi_threadgroup_thread>(NVSHMEMX_PE_ALL, NULL, 1);
+
             for (int i = 0; i < k - 1; i += 1) {
                 nvshmemi_wait_until<uint64_t>((uint64_t *)(pSync + step2_nbrs[phase][i]),
                                               NVSHMEM_CMP_GE, sync_counter[0]);
@@ -1145,6 +1148,7 @@ __device__ NVSHMEMI_STATIC NVSHMEMI_DEVICE_ALWAYS_INLINE void gpu_rdxn_recexch_t
             nvshmemi_signal_for_barrier<long>((long *)(pSync + rank), sync_counter[0],
                                               step1_recvfrom[i]);
         }
+        nvshmemi_transfer_fence<nvshmemi_threadgroup_thread>(NVSHMEMX_PE_ALL, NULL, 1);
     } else if (step1_sendto != -1) {
         if (!myIdx)
             nvshmemi_wait_until<uint64_t>((uint64_t *)(pSync + step1_sendto), NVSHMEM_CMP_GE,


### PR DESCRIPTION
NVSHMEM Barrier code was missing a call to fence() to explicitly declare an ordering dependency which is required b/c the barriers use atomic set instead of increment.  The QP API changes added a proxy channel corruption for non-qp fence calls.  Both of these changes together fix the "init hang" that the collective perftests were hitting.