### PR TITLE
[Bugfix][feat]: add support for `fp16` and `bf16` dtype aliases for collective operations.

### DIFF
--- a/nvshmem4py/nvshmem/core/collective.py
+++ b/nvshmem4py/nvshmem/core/collective.py
@@ -43,6 +43,13 @@ valid_ops = ["min", "max", "sum", None]
 # Collectives
 valid_collectives = ["reduce", "reducescatter", "alltoall", "fcollect", "broadcast"]
 
+# Mapping from user-facing dtype aliases to NVSHMEM binding dtype names
+# This allows users to use common shorthand like "fp16" and "bf16"
+dtype_aliases = {
+    "fp16": "half",
+    "bf16": "bfloat16",
+}
+
 # Mapping from Cupy/Torch dtypes to NVSHMEM dtype names
 external_to_nvshmem_dtypes = {
     # --------------------
@@ -178,9 +185,12 @@ def collective_on_buffer(coll: str, team: Teams, dest: Buffer, src: Buffer, dtyp
     else:
         size_elem = max(1, size // (n_pes() * dtype_nbytes(dtype)))
 
+
     func_name = ""
     if dtype:
-        func_name += f"{dtype}_"
+        # Normalize dtype alias (e.g., fp16 -> half, bf16 -> bfloat16)
+        normalized_dtype = dtype_aliases.get(dtype, dtype)
+        func_name += f"{normalized_dtype}_"
     if op:
         func_name += f"{op}_"
     func_name += f"{coll}_on_stream"


### PR DESCRIPTION
<html><head></head><body><html><head></head><body><h3>Problem</h3>
<p>Running perftest with <code>-d fp16</code> or <code>-d bf16</code> fails with:</p>
<pre><code class="language-text">AttributeError: module 'nvshmem.bindings' has no attribute 'fp16_sum_reduce_on_stream'
</code></pre>
<pre><code class="language-text">AttributeError: module 'nvshmem.bindings' has no attribute 'bf16_sum_reduce_on_stream'
</code></pre>
<h3>Root Cause</h3>
<p><code>collective_on_buffer</code> constructs binding function names using the user-provided dtype directly (e.g., <code>fp16_sum_reduce_on_stream</code>), but the actual bindings use:</p>
<ul>
<li>
<p><code>half</code> for fp16</p>
</li>
<li>
<p><code>bfloat16</code> for bf16</p>
</li>
</ul>
<h3>Solution</h3>
<p>Added a dtype alias mapping in <code>nvshmem4py/nvshmem/core/collective.py</code> to normalize user-friendly shorthand names to their binding-compatible equivalents:</p>
<ul>
<li>
<p><code>fp16</code> → <code>half</code></p>
</li>
<li>
<p><code>bf16</code> → <code>bfloat16</code></p>
</li>
</ul>
<h3>Changes</h3>
<ul>
<li>
<p><code>nvshmem4py/nvshmem/core/collective.py</code>: Added a <code>dtype_aliases</code> dict and applied normalization before constructing binding function names.</p>
</li>
</ul>
<h3>Testing</h3>
<h4>fp16</h4>
<p><strong>Command:</strong></p>
<pre><code class="language-bash">OMPI_ALLOW_RUN_AS_ROOT=1 \
 OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1 \
mpirun -np 4 -N 4 --bind-to none \
  python nvshmem4py/perftest/reduction_on_stream.py \
    -b 2M -e 2M -f 2 \
    -d fp16 -o sum \
    -w 5 -n 20
</code></pre>
<p><strong>Former error:</strong></p>
<pre><code class="language-text">AttributeError: module 'nvshmem.bindings' has no attribute 'fp16_sum_reduce_on_stream'. Did you mean: 'int16_sum_reduce_on_stream'?
</code></pre>
<p><strong>Now:</strong></p>
<pre><code class="language-text">size(B)     count       type      latency(us)       min_lat(us)       max_lat(us)       algbw(GB/s)    busbw(GB/s)
2097152     1048576     half-sum  27.4416002        25.088            33.824            76.422         114.634
</code></pre>
<h4>bf16</h4>
<p><strong>Command:</strong></p>
<pre><code class="language-bash">OMPI_ALLOW_RUN_AS_ROOT=1 \
 OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1 \
mpirun -np 4 -N 4 --bind-to none \
  python nvshmem4py/perftest/reduction_on_stream.py \
    -b 2M -e 2M -f 2 \
    -d bf16 -o sum \
    -w 5 -n 20
</code></pre>
<p><strong>Former error:</strong></p>
<pre><code class="language-text">AttributeError: module 'nvshmem.bindings' has no attribute 'bf16_sum_reduce_on_stream'. Did you mean: 'int16_sum_reduce_on_stream'?
</code></pre>
<p><strong>Now:</strong></p>
<pre><code class="language-text">size(B)     count       type           latency(us)       min_lat(us)       max_lat(us)       algbw(GB/s)    busbw(GB/s)
2097152     1048576     bfloat16-sum   34.4000001        25.280            147.360           60.964         91.446
</code></pre>
<h3>Known Issue (Out of Scope)</h3>
<p>The following dtypes are listed in the perftest argument parser choices but have no corresponding bindings:</p>
<ul>
<li>
<p><code>ulonglong</code> — missing <code>ulonglong_*_reduce_on_stream</code> bindings</p>
</li>
<li>
<p><code>ptrdiff</code> — missing <code>ptrdiff_*_reduce_on_stream</code> bindings</p>
</li>
</ul>
<p>These will fail at runtime if used. Consider adding bindings or removing these from the supported choices in a future PR.</p>
<h3>Dtype Compatibility Analysis</h3>

User Input | Binding Function Exists? | Notes
-- | -- | --
int | ✅ | int_sum_reduce_on_stream
int32 | ✅ | int32_sum_reduce_on_stream
uint32 | ✅ | uint32_sum_reduce_on_stream
int64 | ✅ | int64_sum_reduce_on_stream
uint64 | ✅ | uint64_sum_reduce_on_stream
long | ✅ | long_sum_reduce_on_stream
longlong | ✅ | longlong_sum_reduce_on_stream
ulonglong | ❌ | Missing: no ulonglong_sum_reduce_on_stream
size | ✅ | size_sum_reduce_on_stream
ptrdiff | ❌ | Missing: no ptrdiff_sum_reduce_on_stream
float | ✅ | float_sum_reduce_on_stream
double | ✅ | double_sum_reduce_on_stream
fp16 | ✅ | Maps to half_sum_reduce_on_stream (with this fix)
bf16 | ✅ | Maps to bfloat16_sum_reduce_on_stream (with this fix)

</body></html></body></html>