### PR TITLE
Fix `nvshmemi_ibgda_device_state_d` declaration to avoid multiple definitions

### DIFF
--- a/src/include/device_host_transport/nvshmem_common_ibgda.h
+++ b/src/include/device_host_transport/nvshmem_common_ibgda.h
@@ -344,11 +344,11 @@ typedef nvshmemi_ibgda_device_state_v2 nvshmemi_ibgda_device_state_t;
 #define EXTERN_CONSTANT extern __constant__
 #elif defined(__clang__)
 #define EXTERN_CONSTANT extern __constant__ __attribute__((address_space(4)))
-#else
-#define EXTERN_CONSTANT
 #endif
 
+#ifdef EXTERN_CONSTANT
 EXTERN_CONSTANT nvshmemi_ibgda_device_state_t nvshmemi_ibgda_device_state_d;
 #undef EXTERN_CONSTANT
+#endif
 
 #endif /* _NVSHMEMI_IBGDA_COMMON_H_ */


### PR DESCRIPTION
### Description
This PR fixes an issue with the declaration of `nvshmemi_ibgda_device_state_d` in `src/include/device_host_transport/nvshmem_common_ibgda.h`.

Previously, the `#else` block defined `EXTERN_CONSTANT` as empty, which caused `nvshmemi_ibgda_device_state_d` to be declared as a standard global variable in environments that didn't match the `__CUDACC_RDC__`, `__NVSHMEM_NUMBA_SUPPORT__`, or `__clang__` checks. This could result in multiple definition linker errors.

The fix ensures that `nvshmemi_ibgda_device_state_d` is only declared when `EXTERN_CONSTANT` is properly defined for the target environment (CUDA RDC, Numba, or Clang address space 4).

### Changes
- Modified the preprocessor logic to remove the empty `#define EXTERN_CONSTANT` in the `#else` case.
- Wrapped the declaration of### Description
This PR fixes an issue with the declaration of `nvshmemi_ibgda_device_state_d` in `src/include/device_host_transport/nvshmem_common_ibgda.h`.

Previously, the `#else` block defined `EXTERN_CONSTANT` as empty, which caused `nvshmemi_ibgda_device_state_d` to be declared as a standard global variable in environments that didn't match the `__CUDACC_RDC__`, `__NVSHMEM_NUMBA_SUPPORT__`, or `__clang__` checks. This could result in multiple definition linker errors.

The fix ensures that `nvshmemi_ibgda_device_state_d` is only declared when `EXTERN_CONSTANT` is properly defined for the target environment (CUDA RDC, Numba, or Clang address space 4).

### Changes
- Modified the preprocessor logic to remove the empty `#define EXTERN_CONSTANT` in the `#else` case.
- Wrapped the declaration of `nvshmemi_ibgda_device_state_d` in an #ifdef EXTERN_CONSTANT block.