### PR TITLE
src/modules/transport:  fix unused variable warnings in ibgda/ibrc

### DIFF
--- a/src/modules/transport/ibgda/ibgda.cpp
+++ b/src/modules/transport/ibgda/ibgda.cpp
@@ -1032,9 +1032,6 @@ static int ibgda_gpu_mem_alloc(struct ibgda_mem_object **pmobject, size_t size, 
     void *aligned_ptr;
     size_t bufsize = size;
 
-    void *cpu_ptr_base = NULL;
-    void *cpu_ptr = NULL;
-
     struct ibgda_mem_object *mobject =
         (struct ibgda_mem_object *)calloc(1, sizeof(struct ibgda_mem_object));
     NVSHMEMI_NULL_ERROR_JMP(mobject, status, NVSHMEMX_ERROR_OUT_OF_MEMORY, out,
@@ -1066,6 +1063,9 @@ static int ibgda_gpu_mem_alloc(struct ibgda_mem_object **pmobject, size_t size, 
     if (host_mapping) {
 #ifdef NVSHMEM_USE_GDRCOPY
         if (use_gdrcopy) {
+            void *cpu_ptr_base = NULL;
+            void *cpu_ptr = NULL;
+
             status = gdrcopy_ftable.pin_buffer(gdr_desc, (unsigned long)aligned_ptr,
                                                IBGDA_ROUND_UP(size, IBGDA_GPAGE_SIZE), 0, 0,
                                                &mobject->mh);

--- a/src/modules/transport/ibrc/ibrc.cpp
+++ b/src/modules/transport/ibrc/ibrc.cpp
@@ -1194,8 +1194,6 @@ int nvshmemt_ibrc_amo(struct nvshmem_transport *tcurr, int pe, void *curetptr, a
     struct ibv_send_wr *sr, **bad_sr;
     struct ibv_sge *sge;
     int op_id;
-    struct ibrc_atomic_op op;
-
     ep = (struct ibrc_ep *)nvshmemt_ib_common_get_ep_from_qp_index(tcurr, qp_index, pe);
 
     status = nvshmemt_ib_common_check_poll_avail(tcurr, ep, NVSHMEMT_IB_COMMON_WAIT_ANY);
@@ -1236,6 +1234,8 @@ int nvshmemt_ibrc_amo(struct nvshmem_transport *tcurr, int pe, void *curetptr, a
     }
 
 #ifdef NVSHMEM_USE_GDRCOPY
+    struct ibrc_atomic_op op;
+
     /* we track if the memory handle is EGM based so that GDRCOPY can be disabled*/
     is_egm = check_egm(remote->remote_memdesc.ptr, tcurr->egm_map);
     if (is_egm) {


### PR DESCRIPTION
- move GDRCopy-only temps inside NVSHMEM_USE_GDRCOPY guards in ibgda/ibrc
- avoid unused-variable warnings when GDRCopy is disabled