### PR TITLE
[cmake] Add controls for selective nvshmem4py wheel generation

### DIFF
--- a/nvshmem4py/CMakeLists.txt
+++ b/nvshmem4py/CMakeLists.txt
@@ -3,6 +3,11 @@
 
 cmake_minimum_required(VERSION 3.15)
 
+# Options for controlling nvshmem4py wheel builds
+option(NVSHMEM4PY_BUILD_ALL_WHEELS "Build all nvshmem4py wheels automatically during normal build" ON)
+set(NVSHMEM4PY_PYTHON_VERSIONS "" CACHE STRING "Specific Python versions to build wheels for (e.g., '3.12' or '3.12;3.11'). If empty, all available versions >= 3.9 are used.")
+set(NVSHMEM4PY_CUDA_VERSIONS "" CACHE STRING "Specific CUDA versions to build wheels for (e.g., '12' or '12;13'). If empty, defaults to '12;13'.")
+
 # NVSHMEM_FORCE_REBUILD_PYTHON_LIB is defined in NVSHMEMEnv.cmake
 
 # Must run before addCybind/addNumbast/generateCuteBindings so they can recreate targets
@@ -82,17 +87,71 @@ if(TARGET pip_install_cybind AND TARGET pip_install_numbast)
 endif()
 
 
-# Find all the Python versions
-# Use bash to find all Python versions >= 3.9
-execute_process(
-    COMMAND bash -c "${CMAKE_CURRENT_SOURCE_DIR}/scripts/find_python_versions.sh"
-    OUTPUT_VARIABLE PYTHON_VERSION_LINES
-    OUTPUT_STRIP_TRAILING_WHITESPACE
-)
+# Determine which Python versions to build wheels for
+set(PYTHON_LINE_LIST "")
 
-# Each line is now "3.10|/usr/bin/python3.10"
-# Convert to list
-string(REPLACE "\n" ";" PYTHON_LINE_LIST "${PYTHON_VERSION_LINES}")
+if(NVSHMEM4PY_PYTHON_VERSIONS)
+    message(STATUS "Using filtered Python versions: ${NVSHMEM4PY_PYTHON_VERSIONS}")
+
+    foreach(PY_VER IN LISTS NVSHMEM4PY_PYTHON_VERSIONS)
+        string(REPLACE "." ";" VER_PARTS "${PY_VER}")
+        list(LENGTH VER_PARTS VER_PARTS_LEN)
+
+        if(VER_PARTS_LEN EQUAL 2)
+            list(GET VER_PARTS 0 PY_MAJOR)
+            list(GET VER_PARTS 1 PY_MINOR)
+        else()
+            message(FATAL_ERROR "Invalid Python version format: ${PY_VER}. Expected format: 'major.minor' (e.g., '3.12')")
+        endif()
+
+        set(OVERRIDE_VAR "NVSHMEM4PY_PYTHON_EXECUTABLE_${PY_MAJOR}_${PY_MINOR}")
+        if(DEFINED ${OVERRIDE_VAR})
+            set(PY_EXEC "${${OVERRIDE_VAR}}")
+            message(STATUS "Using override Python executable for ${PY_VER}: ${PY_EXEC}")
+        else()
+            find_program(PY_EXEC_${PY_VER}
+                NAMES python${PY_VER} python${PY_MAJOR}.${PY_MINOR}
+                DOC "Python ${PY_VER} executable"
+            )
+
+            if(NOT PY_EXEC_${PY_VER})
+                message(WARNING "Python ${PY_VER} not found. Skipping wheel build for this version.")
+                continue()
+            endif()
+
+            set(PY_EXEC "${PY_EXEC_${PY_VER}}")
+        endif()
+
+        if(EXISTS "${PY_EXEC}")
+            execute_process(
+                COMMAND "${PY_EXEC}" -c "import sys; print('%d.%d' % (sys.version_info[0], sys.version_info[1]))"
+                OUTPUT_VARIABLE DETECTED_VER
+                OUTPUT_STRIP_TRAILING_WHITESPACE
+                ERROR_QUIET
+            )
+
+            if(NOT DETECTED_VER STREQUAL PY_VER)
+                message(WARNING "Python executable ${PY_EXEC} reports version ${DETECTED_VER}, expected ${PY_VER}. Skipping.")
+                continue()
+            endif()
+
+            list(APPEND PYTHON_LINE_LIST "${PY_VER}|${PY_EXEC}")
+            message(STATUS "Found Python ${PY_VER}: ${PY_EXEC}")
+        else()
+            message(WARNING "Python executable not found: ${PY_EXEC}")
+        endif()
+    endforeach()
+else()
+    message(STATUS "Auto-detecting all available Python versions >= 3.9")
+    execute_process(
+        COMMAND bash -c "${CMAKE_CURRENT_SOURCE_DIR}/scripts/find_python_versions.sh"
+        OUTPUT_VARIABLE PYTHON_VERSION_LINES
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+
+    # Each line is now "3.10|/usr/bin/python3.10"
+    string(REPLACE "\n" ";" PYTHON_LINE_LIST "${PYTHON_VERSION_LINES}")
+endif()
 
 # Used to create the master target
 set(ALL_WHEEL_TARGETS "")
@@ -103,7 +162,13 @@ foreach(LINE IN LISTS PYTHON_LINE_LIST)
     list(GET PYTHON_PAIR 0 PY_VER)
     list(GET PYTHON_PAIR 1 PY_EXEC)
     message(STATUS "Found Python3 ${PY_EXEC}")
-    set(CUDA_VERSIONS "12" "13")
+
+    if(NVSHMEM4PY_CUDA_VERSIONS)
+        set(CUDA_VERSIONS ${NVSHMEM4PY_CUDA_VERSIONS})
+        message(STATUS "Using filtered CUDA versions: ${CUDA_VERSIONS}")
+    else()
+        set(CUDA_VERSIONS "12" "13")
+    endif()
 
     foreach(CUDA_VER IN LISTS CUDA_VERSIONS)
         set(WHEEL_TARGET build_nvshmem4py_wheel_cu${CUDA_VER}_${PY_VER})
@@ -132,10 +197,19 @@ foreach(LINE IN LISTS PYTHON_LINE_LIST)
     endforeach()
 endforeach()
 
-add_custom_target(build_nvshmem4py_wheels ALL
-    COMMENT "Build all wheels for all Python versions"
-    DEPENDS ${ALL_WHEEL_TARGETS}
-)
+if(NVSHMEM4PY_BUILD_ALL_WHEELS)
+    add_custom_target(build_nvshmem4py_wheels ALL
+        COMMENT "Build all wheels for all Python versions"
+        DEPENDS ${ALL_WHEEL_TARGETS}
+    )
+    message(STATUS "nvshmem4py wheels will be built automatically (NVSHMEM4PY_BUILD_ALL_WHEELS=ON)")
+else()
+    add_custom_target(build_nvshmem4py_wheels
+        COMMENT "Build all wheels for all Python versions"
+        DEPENDS ${ALL_WHEEL_TARGETS}
+    )
+    message(STATUS "nvshmem4py wheels will NOT be built automatically. Use 'ninja build_nvshmem4py_wheels' or individual targets to build them. (NVSHMEM4PY_BUILD_ALL_WHEELS=OFF)")
+endif()
 
 # Install step to add to tarball
 install(

--- a/nvshmem4py/README.md
+++ b/nvshmem4py/README.md
@@ -23,3 +23,25 @@ NVSHMEM4Py is a component of NVSHMEM™. Please see the following public links f
 [Devzone Topic Page](https://forums.developer.nvidia.com/tag/nvshmem)
 
 The maintainers of the NVSHMEM project can also be contacted by e-mail at nvshmem@nvidia.com
+
+Wheel Build Configuration
+*************************
+
+By default, the build system discovers all Python versions >= 3.9 on the system and builds wheels for each one against CUDA 12 and 13. The following CMake options provide control over this behavior:
+
+- ``NVSHMEM4PY_BUILD_ALL_WHEELS`` (default: ``ON``) — When ``OFF``, wheels are not built automatically during ``ninja``. Individual targets like ``build_nvshmem4py_wheel_cu12_3.12`` remain available.
+- ``NVSHMEM4PY_PYTHON_VERSIONS`` — Semicolon-separated list of Python versions to build for (e.g., ``3.12`` or ``3.12;3.11``). When empty, all detected versions are used.
+- ``NVSHMEM4PY_CUDA_VERSIONS`` — Semicolon-separated list of CUDA major versions (e.g., ``12`` or ``12;13``). When empty, defaults to ``12;13``.
+- ``NVSHMEM4PY_PYTHON_EXECUTABLE_<major>_<minor>`` — Override the Python executable path for a specific version (e.g., ``-DNVSHMEM4PY_PYTHON_EXECUTABLE_3_12=/opt/venv/bin/python``).
+
+Example: build only a Python 3.12 / CUDA 12 wheel::
+
+    cmake -DNVSHMEM4PY_BUILD_ALL_WHEELS=OFF \
+          -DNVSHMEM4PY_PYTHON_VERSIONS="3.12" \
+          -DNVSHMEM4PY_CUDA_VERSIONS="12" ..
+    ninja build_nvshmem4py_wheel_cu12_3.12
+
+Example: build NVSHMEM core without any wheels::
+
+    cmake -DNVSHMEM4PY_BUILD_ALL_WHEELS=OFF ..
+    ninja


### PR DESCRIPTION
# Enable building specific nvshmem4py targets

## The problem

I build Nvshmem in CI from git, and I use the `nvcr.io/nvidia/cuda:12.9.1-devel-ubi9` base image. In this case the base image has python3.9 as a system binary but we do our whole build with python3.12 so we really only care about that binding. However it still detects both python3.9 and python3.12, which actually causes failure because I don't have the 3.9 devel packages installed. Not only that if I install them to get around this issue it takes 15 minutes to build the the matrix of 3.9 and 3.12 with cu12 and cu13. 

## This PR

This PR adds CMake options to prevent automatic nvshmem4py wheel builds during normal NVSHMEM core builds, solving the "footgun" where ninja inadvertently triggers builds for every Python/CUDA combination found on the system. Three new cache variables provide control: `NVSHMEM4PY_BUILD_ALL_WHEELS` (default: ON, preserving current behavior), `NVSHMEM4PY_PYTHON_VERSIONS`, and `NVSHMEM4PY_CUDA_VERSIONS`. Users can now disable automatic wheel builds entirely or specify exact Python/CUDA version combinations, with deterministic Python executable resolution via optional override variables (`NVSHMEM4PY_PYTHON_EXECUTABLE_<major>_<minor>`).

## Usage examples

The default behaviour is unchanged, to lookup python versions. However now you can do the following:
```bash
mkdir build && cd build
cmake -DNVSHMEM4PY_BUILD_ALL_WHEELS=OFF \
      -DNVSHMEM4PY_PYTHON_VERSIONS="3.12" \
      -DNVSHMEM4PY_CUDA_VERSIONS="12" \
      ..
ninja build_nvshmem4py_wheel_cu12_3.12

# or

cmake -S . -B build \
  -DNVSHMEM4PY_BUILD_ALL_WHEELS=OFF

ninja -C build
```

