### PR TITLE
fix: correct null-check variable after db_umem registration in ibdevx

### DIFF
--- a/src/modules/transport/ibdevx/ibdevx.cpp
+++ b/src/modules/transport/ibdevx/ibdevx.cpp
@@ -366,7 +366,7 @@ static int nvshmemt_ibdevx_mlx5_qp_create(struct ibdevx_ep *ep, struct ibdevx_de
     NVSHMEMI_NULL_ERROR_JMP(dbr_buf, status, ENOMEM, out, "cannot allocate dbr buf for qpair.\n");
 
     db_umem = mlx5dv_devx_umem_reg(context, dbr_buf, NVSHMEMT_IBDEVX_DBSIZE, 0);
-    NVSHMEMI_NULL_ERROR_JMP(wq_umem, status, NVSHMEMX_ERROR_INTERNAL, out,
+    NVSHMEMI_NULL_ERROR_JMP(db_umem, status, NVSHMEMX_ERROR_INTERNAL, out,
                             "cannot register dbr buf for qpair.\n");
 
     if (device->pdn == 0) {


### PR DESCRIPTION
## Summary

Fixes a copy-paste bug in the ibdevx QP initialization code reported in #74.

After registering `db_umem`, the null-check macro incorrectly checks `wq_umem` instead of `db_umem`:

```cpp
// Before (incorrect):
db_umem = mlx5dv_devx_umem_reg(context, dbr_buf, NVSHMEMT_IBDEVX_DBSIZE, 0);
NVSHMEMI_NULL_ERROR_JMP(wq_umem, ...);  // checks wrong variable

// After (correct):
db_umem = mlx5dv_devx_umem_reg(context, dbr_buf, NVSHMEMT_IBDEVX_DBSIZE, 0);
NVSHMEMI_NULL_ERROR_JMP(db_umem, ...);  // checks the just-registered variable
```

If `db_umem` registration fails and returns `NULL`, the error would go undetected (since `wq_umem` was already successfully registered and is non-null), leading to a later null dereference at line 447 when `db_umem->umem_id` is accessed.

Fixes #74