### PR TITLE
Fixed the swap operator for the double data type in Atomic memory ope…

### DIFF
--- a/src/include/device/nvshmem_defines.h
+++ b/src/include/device/nvshmem_defines.h
@@ -1161,8 +1161,9 @@ NVSHMEM_TYPE_XOR_EMULATE(uint64, uint64_t)
             Type *target_actual =                                                           \
                 (Type *)((char *)peer_base_addr +                                           \
                          ((char *)target - (char *)nvshmemi_device_state_d.heap_base));     \
-                                                                                            \
-            return (Type)atomicExch_system((subType *)target_actual, *((subType *)&value)); \
+            subType old_value =                                                             \
+                    atomicExch_system((subType *)target_actual, *((subType *)&value));      \
+            return *((Type *)&old_value);                                                   \
         } else {                                                                            \
             return nvshmemi_transfer_amo_fetch<Type>((void *)target, (Type)value, 0, pe,    \
                                                      NVSHMEMI_AMO_SWAP);                    \


### PR DESCRIPTION
For the swap operator on double types in AMO operations, a bitwise cast (bitcast) should be used instead of a numeric cast.