### PR TITLE
Reject too-long HCA names

### DIFF
--- a/src/modules/transport/common/transport_common.cpp
+++ b/src/modules/transport/common/transport_common.cpp
@@ -64,6 +64,10 @@ int nvshmemt_parse_hca_list(const char *string, struct nvshmemt_hca_info *hca_li
                 hca_list[if_num].port = -1;
                 hca_list[if_num].count = 1;
             }
+            if (if_counter >= static_cast<int>(sizeof(hca_list[if_num].name) - 1)) {
+                NVSHMEMI_ERROR_PRINT("HCA name too long in HCA list\n");
+                return -1;
+            }
             hca_list[if_num].name[if_counter] = c;
             if_counter++;
         }

--- a/src/modules/transport/common/transport_ib_common.cpp
+++ b/src/modules/transport/common/transport_ib_common.cpp
@@ -1038,6 +1038,7 @@ int nvshmemt_ib_common_parse_hca_filter(struct nvshmemt_ib_hca_filter &filter,
                                         const struct nvshmemt_ib_common_state &state) {
     struct nvshmemi_options_s *options = state.options;
     int log_level = state.log_level;
+    int status = 0;
     filter.hca_list_count = 0;
     filter.pe_hca_map_count = 0;
     filter.user_selection = 0;
@@ -1046,8 +1047,9 @@ int nvshmemt_ib_common_parse_hca_filter(struct nvshmemt_ib_hca_filter &filter,
     if (options->HCA_LIST_provided) {
         filter.user_selection = 1;
         filter.exclude_list = (options->HCA_LIST[0] == '^');
-        filter.hca_list_count =
-            nvshmemt_parse_hca_list(options->HCA_LIST, filter.hca_list, MAX_NUM_HCAS, log_level);
+        status = nvshmemt_parse_hca_list(options->HCA_LIST, filter.hca_list, MAX_NUM_HCAS, log_level);
+        if (status < 0) return NVSHMEMX_ERROR_INVALID_VALUE;
+        filter.hca_list_count = status;
     }
 
     if (options->HCA_PE_MAPPING_provided) {
@@ -1058,8 +1060,10 @@ int nvshmemt_ib_common_parse_hca_filter(struct nvshmemt_ib_hca_filter &filter,
                 "NVSHMEM_HCA_PE_MAPPING \n");
         } else {
             filter.user_selection = 1;
-            filter.pe_hca_map_count = nvshmemt_parse_hca_list(
-                options->HCA_PE_MAPPING, filter.pe_hca_mapping, MAX_NUM_PES_PER_NODE, log_level);
+            status = nvshmemt_parse_hca_list(options->HCA_PE_MAPPING, filter.pe_hca_mapping,
+                                             MAX_NUM_PES_PER_NODE, log_level);
+            if (status < 0) return NVSHMEMX_ERROR_INVALID_VALUE;
+            filter.pe_hca_map_count = status;
         }
     }
 

--- a/src/modules/transport/gpunetio/gpunetio.cpp
+++ b/src/modules/transport/gpunetio/gpunetio.cpp
@@ -1247,7 +1247,8 @@ int nvshmemt_gpunetio_state_t::init_nic_devices(nvshmem_transport *transport,
     struct nvshmemt_ib_common_state temp_state = {};
     temp_state.options = options;
     temp_state.log_level = log_level;
-    nvshmemt_ib_common_parse_hca_filter(hca_filter, temp_state);
+    status = nvshmemt_ib_common_parse_hca_filter(hca_filter, temp_state);
+    NVSHMEMI_NZ_ERROR_RET(status, NVSHMEMX_ERROR_INVALID_VALUE, "HCA filter parsing failed.\n");
 
     struct nvshmemt_ib_common_device common_devs[MAX_NUM_HCAS] = {};
     int temp_dev_ids[MAX_NUM_PES_PER_NODE];

--- a/src/modules/transport/ibdevx/ibdevx.cpp
+++ b/src/modules/transport/ibdevx/ibdevx.cpp
@@ -1803,7 +1803,9 @@ int nvshmemt_init(nvshmem_transport_t *t, struct nvshmemi_cuda_fn_table *table, 
     status = pthread_mutex_init(&ibdevx_mutex_send_progress, NULL);
     NVSHMEMI_NZ_ERROR_JMP(status, NVSHMEMX_ERROR_INTERNAL, out, "pthread_mutex_init failed \n");
 
-    nvshmemt_ib_common_parse_hca_filter(hca_filter, *ibdevx_state);
+    status = nvshmemt_ib_common_parse_hca_filter(hca_filter, *ibdevx_state);
+    NVSHMEMI_NZ_ERROR_JMP(status, NVSHMEMX_ERROR_INVALID_VALUE, out,
+                          "HCA filter parsing failed.\n");
 
     status = nvshmemt_ib_common_enumerate_devices(
         &ftable, *ibdevx_state, sizeof(struct ibdevx_device), hca_filter, dev_list, num_devices);

--- a/src/modules/transport/ibgda/ibgda.cpp
+++ b/src/modules/transport/ibgda/ibgda.cpp
@@ -4848,7 +4848,9 @@ int nvshmemt_init(nvshmem_transport_t *t, struct nvshmemi_cuda_fn_table *table, 
     ibgda_state->common.port_ids = (int *)malloc(MAX_NUM_PES_PER_NODE * sizeof(int));
     NVSHMEMI_NULL_ERROR_JMP(ibgda_state->common.port_ids, status, NVSHMEMX_ERROR_OUT_OF_MEMORY, out,
                             "malloc failed \n");
-    nvshmemt_ib_common_parse_hca_filter(hca_filter, ibgda_state->common);
+    status = nvshmemt_ib_common_parse_hca_filter(hca_filter, ibgda_state->common);
+    NVSHMEMI_NZ_ERROR_JMP(status, NVSHMEMX_ERROR_INVALID_VALUE, out,
+                          "HCA filter parsing failed.\n");
 
     nic_mapping_memtype_request =
         ibgda_parse_nic_mapping_memtype_request(options->IBGDA_FORCE_NIC_BUF_MEMTYPE);

--- a/src/modules/transport/ibrc/ibrc.cpp
+++ b/src/modules/transport/ibrc/ibrc.cpp
@@ -1746,7 +1746,9 @@ int nvshmemt_init(nvshmem_transport_t *t, struct nvshmemi_cuda_fn_table *table, 
     ibrc_state->srq_depth = ibrc_state->options->SRQ_DEPTH;
     // qp_depth and srq_depth are now accessed directly from ibrc_state
 
-    nvshmemt_ib_common_parse_hca_filter(hca_filter, *ibrc_state);
+    status = nvshmemt_ib_common_parse_hca_filter(hca_filter, *ibrc_state);
+    NVSHMEMI_NZ_ERROR_JMP(status, NVSHMEMX_ERROR_INVALID_VALUE, out,
+                          "HCA filter parsing failed.\n");
 
     status = nvshmemt_ib_common_enumerate_devices(&ftable, *ibrc_state, sizeof(struct ibrc_device),
                                                   hca_filter, dev_list, num_devices);


### PR DESCRIPTION
## Summary
- Reject HCA list entries whose names would exceed the fixed `nvshmemt_hca_info::name` buffer.
- Propagate parser failures through shared HCA filter setup and the IB transport init paths that consume it.

## Root cause
`nvshmemt_parse_hca_list()` appended HCA name characters without checking the `name[64]` capacity. The unsafe append is present from the public import; later shared-IB refactoring preserved the behavior.

## Testing
- `git diff --check`
- CMake configure attempted with tests enabled and unrelated build pieces disabled; blocked locally because CUDA toolkit / `nvcc` is not installed (`Failed to find nvcc`).
