### PR TITLE
nvshmem4py: support torch.float8_e4m3fn / float8_e5m2 tensor allocation

### DIFF
--- a/nvshmem4py/nvshmem/core/utils.py
+++ b/nvshmem4py/nvshmem/core/utils.py
@@ -25,6 +25,8 @@ try:
     torch_to_numpy = {
         torch.float16: np.float16,
         torch.bfloat16: np.float16,  # Note: bfloat16 isn't supported by default in NumPy
+        torch.float8_e4m3fn: np.uint8,  # Note: FP8 isn't supported by NumPy; only itemsize is used
+        torch.float8_e5m2: np.uint8,
         torch.float32: np.float32,
         torch.float64: np.float64,
         torch.int8: np.int8,

--- a/nvshmem4py/test/memory_test.py
+++ b/nvshmem4py/test/memory_test.py
@@ -160,6 +160,27 @@ def test_interop_torch():
     print("Ending test Torch interop buffer")
 
 
+def test_interop_torch_fp8():
+    print("Testing Torch interop buffer with FP8 dtypes")
+    if not _torch_enabled:
+        print("WARNING: Torch not found. Not running FP8 Torch Interop test")
+        return
+    for dtype in (torch.float8_e4m3fn, torch.float8_e5m2):
+        tensor = nvshmem.core.tensor((16, 32), dtype=dtype)
+        assert tensor.dtype == dtype
+        assert tensor.element_size() == 1
+        # FP8 elementwise assignment isn't available in every Torch version, so
+        # write through a byte view.
+        byte_view = tensor.view(torch.uint8)
+        assert byte_view.numel() == 16 * 32
+        byte_view[:] = 0xA5
+        assert byte_view.min().item() == 0xA5
+        assert byte_view.max().item() == 0xA5
+        print(dtype, tuple(tensor.shape))
+        nvshmem.core.free_tensor(tensor)
+    print("Ending test Torch interop buffer with FP8 dtypes")
+
+
 def test_interop_cupy():
     print("Testing CuPy interop mem")
     if not _cupy_enabled:
@@ -614,6 +635,7 @@ if __name__ == '__main__':
         test_peer_tensor()
         test_interop_cupy()
         test_interop_torch()
+        test_interop_torch_fp8()
         test_del_buffer()
         test_mc_buffer()
         test_mc_tensor()


### PR DESCRIPTION
Allocating symmetric memory with an FP8 dtype fails:

```
>>> nvshmem.core.tensor((16, 32), dtype=torch.float8_e4m3fn)
ValueError: Unsupported torch dtype: torch.float8_e4m3fn
```

Same for `torch.float8_e5m2`. `torch_to_numpy` in `nvshmem4py/nvshmem/core/utils.py` has no FP8 entries, and that map is what `get_size()` consults; `tensor()` then allocates that many bytes and calls `.view(dtype)`, which works for FP8.

The map's only consumer is `get_size`, and only `itemsize` is read from it, so a same-width stand-in is enough. NumPy has no FP8 type, so `np.uint8` it is — one byte, and the value is never interpreted through it. Same workaround `bfloat16` already uses. The new entries need Torch 2.1; the table already references `torch.uint16`/`uint32`/`uint64`, which need 2.3, so the effective floor doesn't move.

Checked on H100 / Torch 2.12 / NVSHMEM 3.7.2 at a single PE. Before the change, both FP8 dtypes raise from `get_size` and `bfloat16` allocates normally. After, all three allocate, with FP8 at 512 bytes and `bfloat16` at 1024 for a (16, 32) tensor — matching `Tensor.element_size()` — and a byte-view write reads back intact.

This also affects the CuTe interop path, which calls the same `get_size`, so FP8 buffers can't be allocated there either today. That is the case I hit: CUTLASS's CuTeDSL distributed utilities provide `multimem.ld_reduce` variants for `e4m3` and `e5m2`, with nothing on the NVSHMEM side to allocate for them.

`test_interop_torch_fp8` in `nvshmem4py/test/memory_test.py` covers it; the same sequence raises `ValueError` on unpatched `utils.py`.

One question: would you rather the table also carry `float8_e4m3fnuz` / `float8_e5m2fnuz`? I left them out as non-NVIDIA formats, but they are one line each.