### PR TITLE
nvshmem4py: add bfloat16 to the CuTe device-side dispatch

### DIFF
--- a/nvshmem4py/nvshmem/core/device/cute/collective.py
+++ b/nvshmem4py/nvshmem/core/device/cute/collective.py
@@ -409,6 +409,9 @@ def reduce_block(team, dst, src, op):
         elif const_expr(dtype == cutlass.Float16):
             return half_min_reduce_block(team, dst_ptr, src_ptr, nelem)
 
+        elif const_expr(dtype == cutlass.BFloat16):
+            return bfloat16_min_reduce_block(team, dst_ptr, src_ptr, nelem)
+
 
     elif const_expr(op == "max"):
 
@@ -444,6 +447,9 @@ def reduce_block(team, dst, src, op):
 
         elif const_expr(dtype == cutlass.Float16):
             return half_max_reduce_block(team, dst_ptr, src_ptr, nelem)
+
+        elif const_expr(dtype == cutlass.BFloat16):
+            return bfloat16_max_reduce_block(team, dst_ptr, src_ptr, nelem)
 
 
     elif const_expr(op == "sum"):
@@ -481,6 +487,9 @@ def reduce_block(team, dst, src, op):
         elif const_expr(dtype == cutlass.Float16):
             return half_sum_reduce_block(team, dst_ptr, src_ptr, nelem)
 
+        elif const_expr(dtype == cutlass.BFloat16):
+            return bfloat16_sum_reduce_block(team, dst_ptr, src_ptr, nelem)
+
 
     elif const_expr(op == "prod"):
 
@@ -516,6 +525,9 @@ def reduce_block(team, dst, src, op):
 
         elif const_expr(dtype == cutlass.Float16):
             return half_prod_reduce_block(team, dst_ptr, src_ptr, nelem)
+
+        elif const_expr(dtype == cutlass.BFloat16):
+            return bfloat16_prod_reduce_block(team, dst_ptr, src_ptr, nelem)
 
 
 
@@ -669,6 +681,9 @@ def reduce_warp(team, dst, src, op):
         elif const_expr(dtype == cutlass.Float16):
             return half_min_reduce_warp(team, dst_ptr, src_ptr, nelem)
 
+        elif const_expr(dtype == cutlass.BFloat16):
+            return bfloat16_min_reduce_warp(team, dst_ptr, src_ptr, nelem)
+
 
     elif const_expr(op == "max"):
 
@@ -704,6 +719,9 @@ def reduce_warp(team, dst, src, op):
 
         elif const_expr(dtype == cutlass.Float16):
             return half_max_reduce_warp(team, dst_ptr, src_ptr, nelem)
+
+        elif const_expr(dtype == cutlass.BFloat16):
+            return bfloat16_max_reduce_warp(team, dst_ptr, src_ptr, nelem)
 
 
     elif const_expr(op == "sum"):
@@ -741,6 +759,9 @@ def reduce_warp(team, dst, src, op):
         elif const_expr(dtype == cutlass.Float16):
             return half_sum_reduce_warp(team, dst_ptr, src_ptr, nelem)
 
+        elif const_expr(dtype == cutlass.BFloat16):
+            return bfloat16_sum_reduce_warp(team, dst_ptr, src_ptr, nelem)
+
 
     elif const_expr(op == "prod"):
 
@@ -776,6 +797,9 @@ def reduce_warp(team, dst, src, op):
 
         elif const_expr(dtype == cutlass.Float16):
             return half_prod_reduce_warp(team, dst_ptr, src_ptr, nelem)
+
+        elif const_expr(dtype == cutlass.BFloat16):
+            return bfloat16_prod_reduce_warp(team, dst_ptr, src_ptr, nelem)
 
 
 
@@ -929,6 +953,9 @@ def reduce(team, dst, src, op):
         elif const_expr(dtype == cutlass.Float16):
             return half_min_reduce(team, dst_ptr, src_ptr, nelem)
 
+        elif const_expr(dtype == cutlass.BFloat16):
+            return bfloat16_min_reduce(team, dst_ptr, src_ptr, nelem)
+
 
     elif const_expr(op == "max"):
 
@@ -964,6 +991,9 @@ def reduce(team, dst, src, op):
 
         elif const_expr(dtype == cutlass.Float16):
             return half_max_reduce(team, dst_ptr, src_ptr, nelem)
+
+        elif const_expr(dtype == cutlass.BFloat16):
+            return bfloat16_max_reduce(team, dst_ptr, src_ptr, nelem)
 
 
     elif const_expr(op == "sum"):
@@ -1001,6 +1031,9 @@ def reduce(team, dst, src, op):
         elif const_expr(dtype == cutlass.Float16):
             return half_sum_reduce(team, dst_ptr, src_ptr, nelem)
 
+        elif const_expr(dtype == cutlass.BFloat16):
+            return bfloat16_sum_reduce(team, dst_ptr, src_ptr, nelem)
+
 
     elif const_expr(op == "prod"):
 
@@ -1036,6 +1069,9 @@ def reduce(team, dst, src, op):
 
         elif const_expr(dtype == cutlass.Float16):
             return half_prod_reduce(team, dst_ptr, src_ptr, nelem)
+
+        elif const_expr(dtype == cutlass.BFloat16):
+            return bfloat16_prod_reduce(team, dst_ptr, src_ptr, nelem)
 
 
 
@@ -1193,6 +1229,9 @@ def reducescatter_block(team, dst, src, op):
         elif const_expr(dtype == cutlass.Float16):
             return half_min_reducescatter_block(team, dst_ptr, src_ptr, nelem)
 
+        elif const_expr(dtype == cutlass.BFloat16):
+            return bfloat16_min_reducescatter_block(team, dst_ptr, src_ptr, nelem)
+
 
     elif const_expr(op == "max"):
 
@@ -1228,6 +1267,9 @@ def reducescatter_block(team, dst, src, op):
 
         elif const_expr(dtype == cutlass.Float16):
             return half_max_reducescatter_block(team, dst_ptr, src_ptr, nelem)
+
+        elif const_expr(dtype == cutlass.BFloat16):
+            return bfloat16_max_reducescatter_block(team, dst_ptr, src_ptr, nelem)
 
 
     elif const_expr(op == "sum"):
@@ -1265,6 +1307,9 @@ def reducescatter_block(team, dst, src, op):
         elif const_expr(dtype == cutlass.Float16):
             return half_sum_reducescatter_block(team, dst_ptr, src_ptr, nelem)
 
+        elif const_expr(dtype == cutlass.BFloat16):
+            return bfloat16_sum_reducescatter_block(team, dst_ptr, src_ptr, nelem)
+
 
     elif const_expr(op == "prod"):
 
@@ -1300,6 +1345,9 @@ def reducescatter_block(team, dst, src, op):
 
         elif const_expr(dtype == cutlass.Float16):
             return half_prod_reducescatter_block(team, dst_ptr, src_ptr, nelem)
+
+        elif const_expr(dtype == cutlass.BFloat16):
+            return bfloat16_prod_reducescatter_block(team, dst_ptr, src_ptr, nelem)
 
 
 
@@ -1454,6 +1502,9 @@ def reducescatter_warp(team, dst, src, op):
         elif const_expr(dtype == cutlass.Float16):
             return half_min_reducescatter_warp(team, dst_ptr, src_ptr, nelem)
 
+        elif const_expr(dtype == cutlass.BFloat16):
+            return bfloat16_min_reducescatter_warp(team, dst_ptr, src_ptr, nelem)
+
 
     elif const_expr(op == "max"):
 
@@ -1489,6 +1540,9 @@ def reducescatter_warp(team, dst, src, op):
 
         elif const_expr(dtype == cutlass.Float16):
             return half_max_reducescatter_warp(team, dst_ptr, src_ptr, nelem)
+
+        elif const_expr(dtype == cutlass.BFloat16):
+            return bfloat16_max_reducescatter_warp(team, dst_ptr, src_ptr, nelem)
 
 
     elif const_expr(op == "sum"):
@@ -1526,6 +1580,9 @@ def reducescatter_warp(team, dst, src, op):
         elif const_expr(dtype == cutlass.Float16):
             return half_sum_reducescatter_warp(team, dst_ptr, src_ptr, nelem)
 
+        elif const_expr(dtype == cutlass.BFloat16):
+            return bfloat16_sum_reducescatter_warp(team, dst_ptr, src_ptr, nelem)
+
 
     elif const_expr(op == "prod"):
 
@@ -1561,6 +1618,9 @@ def reducescatter_warp(team, dst, src, op):
 
         elif const_expr(dtype == cutlass.Float16):
             return half_prod_reducescatter_warp(team, dst_ptr, src_ptr, nelem)
+
+        elif const_expr(dtype == cutlass.BFloat16):
+            return bfloat16_prod_reducescatter_warp(team, dst_ptr, src_ptr, nelem)
 
 
 
@@ -1715,6 +1775,9 @@ def reducescatter(team, dst, src, op):
         elif const_expr(dtype == cutlass.Float16):
             return half_min_reducescatter(team, dst_ptr, src_ptr, nelem)
 
+        elif const_expr(dtype == cutlass.BFloat16):
+            return bfloat16_min_reducescatter(team, dst_ptr, src_ptr, nelem)
+
 
     elif const_expr(op == "max"):
 
@@ -1750,6 +1813,9 @@ def reducescatter(team, dst, src, op):
 
         elif const_expr(dtype == cutlass.Float16):
             return half_max_reducescatter(team, dst_ptr, src_ptr, nelem)
+
+        elif const_expr(dtype == cutlass.BFloat16):
+            return bfloat16_max_reducescatter(team, dst_ptr, src_ptr, nelem)
 
 
     elif const_expr(op == "sum"):
@@ -1787,6 +1853,9 @@ def reducescatter(team, dst, src, op):
         elif const_expr(dtype == cutlass.Float16):
             return half_sum_reducescatter(team, dst_ptr, src_ptr, nelem)
 
+        elif const_expr(dtype == cutlass.BFloat16):
+            return bfloat16_sum_reducescatter(team, dst_ptr, src_ptr, nelem)
+
 
     elif const_expr(op == "prod"):
 
@@ -1822,6 +1891,9 @@ def reducescatter(team, dst, src, op):
 
         elif const_expr(dtype == cutlass.Float16):
             return half_prod_reducescatter(team, dst_ptr, src_ptr, nelem)
+
+        elif const_expr(dtype == cutlass.BFloat16):
+            return bfloat16_prod_reducescatter(team, dst_ptr, src_ptr, nelem)
 
 
 
@@ -1974,6 +2046,9 @@ def fcollect_block(team, dst, src):
     elif const_expr(dtype == cutlass.Float16):
         return half_fcollect_block(team, dst_ptr, src_ptr, nelem)
 
+    elif const_expr(dtype == cutlass.BFloat16):
+        return bfloat16_fcollect_block(team, dst_ptr, src_ptr, nelem)
+
     raise RuntimeError(f"Unsupported CuTe dtype for fcollect: {dtype}")
 
 
@@ -2039,6 +2114,9 @@ def fcollect_warp(team, dst, src):
     elif const_expr(dtype == cutlass.Float16):
         return half_fcollect_warp(team, dst_ptr, src_ptr, nelem)
 
+    elif const_expr(dtype == cutlass.BFloat16):
+        return bfloat16_fcollect_warp(team, dst_ptr, src_ptr, nelem)
+
     raise RuntimeError(f"Unsupported CuTe dtype for fcollect: {dtype}")
 
 
@@ -2103,6 +2181,9 @@ def fcollect(team, dst, src):
 
     elif const_expr(dtype == cutlass.Float16):
         return half_fcollect(team, dst_ptr, src_ptr, nelem)
+
+    elif const_expr(dtype == cutlass.BFloat16):
+        return bfloat16_fcollect(team, dst_ptr, src_ptr, nelem)
 
     raise RuntimeError(f"Unsupported CuTe dtype for fcollect: {dtype}")
 
@@ -2172,6 +2253,9 @@ def broadcast_block(team, dst, src, root=0):
     elif const_expr(dtype == cutlass.Float16):
         return half_broadcast_block(team, dst_ptr, src_ptr, nelem, root)
 
+    elif const_expr(dtype == cutlass.BFloat16):
+        return bfloat16_broadcast_block(team, dst_ptr, src_ptr, nelem, root)
+
     raise RuntimeError(f"Unsupported CuTe dtype for broadcast: {dtype}")
 
 
@@ -2237,6 +2321,9 @@ def broadcast_warp(team, dst, src, root=0):
     elif const_expr(dtype == cutlass.Float16):
         return half_broadcast_warp(team, dst_ptr, src_ptr, nelem, root)
 
+    elif const_expr(dtype == cutlass.BFloat16):
+        return bfloat16_broadcast_warp(team, dst_ptr, src_ptr, nelem, root)
+
     raise RuntimeError(f"Unsupported CuTe dtype for broadcast: {dtype}")
 
 
@@ -2301,6 +2388,9 @@ def broadcast(team, dst, src, root=0):
 
     elif const_expr(dtype == cutlass.Float16):
         return half_broadcast(team, dst_ptr, src_ptr, nelem, root)
+
+    elif const_expr(dtype == cutlass.BFloat16):
+        return bfloat16_broadcast(team, dst_ptr, src_ptr, nelem, root)
 
     raise RuntimeError(f"Unsupported CuTe dtype for broadcast: {dtype}")
 
@@ -2373,6 +2463,9 @@ def alltoall_block(team, dst, src):
     elif const_expr(dtype == cutlass.Float16):
         return half_alltoall_block(team, dst_ptr, src_ptr, nelem)
 
+    elif const_expr(dtype == cutlass.BFloat16):
+        return bfloat16_alltoall_block(team, dst_ptr, src_ptr, nelem)
+
     raise RuntimeError(f"Unsupported CuTe dtype for alltoall: {dtype}")
 
 
@@ -2441,6 +2534,9 @@ def alltoall_warp(team, dst, src):
     elif const_expr(dtype == cutlass.Float16):
         return half_alltoall_warp(team, dst_ptr, src_ptr, nelem)
 
+    elif const_expr(dtype == cutlass.BFloat16):
+        return bfloat16_alltoall_warp(team, dst_ptr, src_ptr, nelem)
+
     raise RuntimeError(f"Unsupported CuTe dtype for alltoall: {dtype}")
 
 
@@ -2508,5 +2604,8 @@ def alltoall(team, dst, src):
 
     elif const_expr(dtype == cutlass.Float16):
         return half_alltoall(team, dst_ptr, src_ptr, nelem)
+
+    elif const_expr(dtype == cutlass.BFloat16):
+        return bfloat16_alltoall(team, dst_ptr, src_ptr, nelem)
 
     raise RuntimeError(f"Unsupported CuTe dtype for alltoall: {dtype}")

--- a/nvshmem4py/nvshmem/core/device/cute/rma.py
+++ b/nvshmem4py/nvshmem/core/device/cute/rma.py
@@ -94,6 +94,9 @@ def put_block(dst, src, pe):
     elif const_expr(dtype == cutlass.Float16):
         return half_put_block(dst_ptr, src_ptr, nelems, pe)
 
+    elif const_expr(dtype == cutlass.BFloat16):
+        return bfloat16_put_block(dst_ptr, src_ptr, nelems, pe)
+
     raise RuntimeError(f"Unsupported CuTe dtype for RMA dispatch: {dtype}")
 
 
@@ -154,6 +157,9 @@ def put_nbi_block(dst, src, pe):
 
     elif const_expr(dtype == cutlass.Float16):
         return half_put_nbi_block(dst_ptr, src_ptr, nelems, pe)
+
+    elif const_expr(dtype == cutlass.BFloat16):
+        return bfloat16_put_nbi_block(dst_ptr, src_ptr, nelems, pe)
 
     raise RuntimeError(f"Unsupported CuTe dtype for RMA dispatch: {dtype}")
 
@@ -217,6 +223,9 @@ def put_warp(dst, src, pe):
     elif const_expr(dtype == cutlass.Float16):
         return half_put_warp(dst_ptr, src_ptr, nelems, pe)
 
+    elif const_expr(dtype == cutlass.BFloat16):
+        return bfloat16_put_warp(dst_ptr, src_ptr, nelems, pe)
+
     raise RuntimeError(f"Unsupported CuTe dtype for RMA dispatch: {dtype}")
 
 
@@ -277,6 +286,9 @@ def put_nbi_warp(dst, src, pe):
 
     elif const_expr(dtype == cutlass.Float16):
         return half_put_nbi_warp(dst_ptr, src_ptr, nelems, pe)
+
+    elif const_expr(dtype == cutlass.BFloat16):
+        return bfloat16_put_nbi_warp(dst_ptr, src_ptr, nelems, pe)
 
     raise RuntimeError(f"Unsupported CuTe dtype for RMA dispatch: {dtype}")
 
@@ -340,6 +352,9 @@ def put(dst, src, pe):
     elif const_expr(dtype == cutlass.Float16):
         return half_put(dst_ptr, src_ptr, nelems, pe)
 
+    elif const_expr(dtype == cutlass.BFloat16):
+        return bfloat16_put(dst_ptr, src_ptr, nelems, pe)
+
     raise RuntimeError(f"Unsupported CuTe dtype for RMA dispatch: {dtype}")
 
 
@@ -400,6 +415,9 @@ def put_nbi(dst, src, pe):
 
     elif const_expr(dtype == cutlass.Float16):
         return half_put_nbi(dst_ptr, src_ptr, nelems, pe)
+
+    elif const_expr(dtype == cutlass.BFloat16):
+        return bfloat16_put_nbi(dst_ptr, src_ptr, nelems, pe)
 
     raise RuntimeError(f"Unsupported CuTe dtype for RMA dispatch: {dtype}")
 
@@ -466,6 +484,9 @@ def get_block(dst, src, pe):
     elif const_expr(dtype == cutlass.Float16):
         return half_get_block(dst_ptr, src_ptr, nelems, pe)
 
+    elif const_expr(dtype == cutlass.BFloat16):
+        return bfloat16_get_block(dst_ptr, src_ptr, nelems, pe)
+
     raise RuntimeError(f"Unsupported CuTe dtype for RMA dispatch: {dtype}")
 
 
@@ -526,6 +547,9 @@ def get_nbi_block(dst, src, pe):
 
     elif const_expr(dtype == cutlass.Float16):
         return half_get_nbi_block(dst_ptr, src_ptr, nelems, pe)
+
+    elif const_expr(dtype == cutlass.BFloat16):
+        return bfloat16_get_nbi_block(dst_ptr, src_ptr, nelems, pe)
 
     raise RuntimeError(f"Unsupported CuTe dtype for RMA dispatch: {dtype}")
 
@@ -589,6 +613,9 @@ def get_warp(dst, src, pe):
     elif const_expr(dtype == cutlass.Float16):
         return half_get_warp(dst_ptr, src_ptr, nelems, pe)
 
+    elif const_expr(dtype == cutlass.BFloat16):
+        return bfloat16_get_warp(dst_ptr, src_ptr, nelems, pe)
+
     raise RuntimeError(f"Unsupported CuTe dtype for RMA dispatch: {dtype}")
 
 
@@ -649,6 +676,9 @@ def get_nbi_warp(dst, src, pe):
 
     elif const_expr(dtype == cutlass.Float16):
         return half_get_nbi_warp(dst_ptr, src_ptr, nelems, pe)
+
+    elif const_expr(dtype == cutlass.BFloat16):
+        return bfloat16_get_nbi_warp(dst_ptr, src_ptr, nelems, pe)
 
     raise RuntimeError(f"Unsupported CuTe dtype for RMA dispatch: {dtype}")
 
@@ -712,6 +742,9 @@ def get(dst, src, pe):
     elif const_expr(dtype == cutlass.Float16):
         return half_get(dst_ptr, src_ptr, nelems, pe)
 
+    elif const_expr(dtype == cutlass.BFloat16):
+        return bfloat16_get(dst_ptr, src_ptr, nelems, pe)
+
     raise RuntimeError(f"Unsupported CuTe dtype for RMA dispatch: {dtype}")
 
 
@@ -772,6 +805,9 @@ def get_nbi(dst, src, pe):
 
     elif const_expr(dtype == cutlass.Float16):
         return half_get_nbi(dst_ptr, src_ptr, nelems, pe)
+
+    elif const_expr(dtype == cutlass.BFloat16):
+        return bfloat16_get_nbi(dst_ptr, src_ptr, nelems, pe)
 
     raise RuntimeError(f"Unsupported CuTe dtype for RMA dispatch: {dtype}")
 
@@ -849,6 +885,9 @@ def put_signal_block(dst, src, signal_var, signal_val, signal_op, pe):
     elif const_expr(dtype == cutlass.Float16):
         return half_put_signal_block(dst_ptr, src_ptr, nelems, signal_var_ptr, signal_val, signal_op, pe)
 
+    elif const_expr(dtype == cutlass.BFloat16):
+        return bfloat16_put_signal_block(dst_ptr, src_ptr, nelems, signal_var_ptr, signal_val, signal_op, pe)
+
     raise RuntimeError(f"Unsupported CuTe dtype for RMA dispatch: {dtype}")
 
 
@@ -920,6 +959,9 @@ def put_signal_nbi_block(dst, src, signal_var, signal_val, signal_op, pe):
 
     elif const_expr(dtype == cutlass.Float16):
         return half_put_signal_nbi_block(dst_ptr, src_ptr, nelems, signal_var_ptr, signal_val, signal_op, pe)
+
+    elif const_expr(dtype == cutlass.BFloat16):
+        return bfloat16_put_signal_nbi_block(dst_ptr, src_ptr, nelems, signal_var_ptr, signal_val, signal_op, pe)
 
     raise RuntimeError(f"Unsupported CuTe dtype for RMA dispatch: {dtype}")
 
@@ -994,6 +1036,9 @@ def put_signal_warp(dst, src, signal_var, signal_val, signal_op, pe):
     elif const_expr(dtype == cutlass.Float16):
         return half_put_signal_warp(dst_ptr, src_ptr, nelems, signal_var_ptr, signal_val, signal_op, pe)
 
+    elif const_expr(dtype == cutlass.BFloat16):
+        return bfloat16_put_signal_warp(dst_ptr, src_ptr, nelems, signal_var_ptr, signal_val, signal_op, pe)
+
     raise RuntimeError(f"Unsupported CuTe dtype for RMA dispatch: {dtype}")
 
 
@@ -1065,6 +1110,9 @@ def put_signal_nbi_warp(dst, src, signal_var, signal_val, signal_op, pe):
 
     elif const_expr(dtype == cutlass.Float16):
         return half_put_signal_nbi_warp(dst_ptr, src_ptr, nelems, signal_var_ptr, signal_val, signal_op, pe)
+
+    elif const_expr(dtype == cutlass.BFloat16):
+        return bfloat16_put_signal_nbi_warp(dst_ptr, src_ptr, nelems, signal_var_ptr, signal_val, signal_op, pe)
 
     raise RuntimeError(f"Unsupported CuTe dtype for RMA dispatch: {dtype}")
 
@@ -1139,6 +1187,9 @@ def put_signal(dst, src, signal_var, signal_val, signal_op, pe):
     elif const_expr(dtype == cutlass.Float16):
         return half_put_signal(dst_ptr, src_ptr, nelems, signal_var_ptr, signal_val, signal_op, pe)
 
+    elif const_expr(dtype == cutlass.BFloat16):
+        return bfloat16_put_signal(dst_ptr, src_ptr, nelems, signal_var_ptr, signal_val, signal_op, pe)
+
     raise RuntimeError(f"Unsupported CuTe dtype for RMA dispatch: {dtype}")
 
 
@@ -1211,6 +1262,9 @@ def put_signal_nbi(dst, src, signal_var, signal_val, signal_op, pe):
     elif const_expr(dtype == cutlass.Float16):
         return half_put_signal_nbi(dst_ptr, src_ptr, nelems, signal_var_ptr, signal_val, signal_op, pe)
 
+    elif const_expr(dtype == cutlass.BFloat16):
+        return bfloat16_put_signal_nbi(dst_ptr, src_ptr, nelems, signal_var_ptr, signal_val, signal_op, pe)
+
     raise RuntimeError(f"Unsupported CuTe dtype for RMA dispatch: {dtype}")
 
 
@@ -1272,6 +1326,9 @@ def p(dst, src, pe):
     elif const_expr(dtype == cutlass.Float16):
         return half_p(dst_ptr, cute_cast(src, cutlass.Float16), pe)
 
+    elif const_expr(dtype == cutlass.BFloat16):
+        return bfloat16_p(dst_ptr, cute_cast(src, cutlass.BFloat16), pe)
+
     raise RuntimeError(f"Unsupported CuTe dtype for RMA dispatch: {dtype}")
 
 # g variations
@@ -1332,5 +1389,8 @@ def g(src, pe):
 
     elif const_expr(dtype == cutlass.Float16):
         return half_g(src_ptr, pe)
+
+    elif const_expr(dtype == cutlass.BFloat16):
+        return bfloat16_g(src_ptr, pe)
 
     raise RuntimeError(f"Unsupported CuTe dtype for RMA dispatch: {dtype}")

--- a/nvshmem4py/test/device/cute/test_device_coll.py
+++ b/nvshmem4py/test/device/cute/test_device_coll.py
@@ -26,6 +26,7 @@ from utils import (
 # TODO: float32 collectives hit proxy timeout on PCIe systems (L40S). Investigate.
 # Excluding float32 until the root cause is found.
 coll_dtypes = [
+    "bfloat16",
     pytest.param("float32", marks=pytest.mark.xfail(reason="proxy timeout on PCIe (Bug TBD)", strict=False)),
     "float64",
     "int8",
@@ -39,6 +40,8 @@ coll_dtypes = [
 ]
 
 _NUMPY_DTYPE_MAP = {
+    # NumPy has no bfloat16, and _read_cute_tensor promotes it to float32.
+    "bfloat16": np.float32,
     "float32": np.float32,
     "float64": np.float64,
     "int8": np.int8,

--- a/nvshmem4py/test/device/cute/test_device_rma.py
+++ b/nvshmem4py/test/device/cute/test_device_rma.py
@@ -16,9 +16,12 @@ import nvshmem.bindings.device.cute as nvshmem_cute_bindings
 
 _KERNEL_OBJECTS: list[nvshmem.core.NvshmemKernelObject] = []
 
-rma_dtypes = ["float32", "float64", "int8", "int16", "int32", "int64", "uint8", "uint16", "uint32", "uint64"]
+rma_dtypes = [
+    "bfloat16", "float32", "float64", "int8", "int16", "int32", "int64", "uint8", "uint16", "uint32", "uint64"
+]
 
 _TORCH_DTYPE_MAP = {
+    "bfloat16": torch.bfloat16,
     "float32": torch.float32,
     "float64": torch.float64,
     "int8": torch.int8,

--- a/nvshmem4py/test/device/cute/utils.py
+++ b/nvshmem4py/test/device/cute/utils.py
@@ -21,6 +21,7 @@ mpi_init = _utils.mpi_init
 get_local_rank_per_node = _utils.get_local_rank_per_node
 
 _CUTE_DTYPE_MAP = {
+    "bfloat16": cute.BFloat16,
     "float32": cute.Float32,
     "float64": cute.Float64,
     "int8": cute.Int8,
@@ -34,6 +35,7 @@ _CUTE_DTYPE_MAP = {
 }
 
 _TORCH_DTYPE_MAP = {
+    "bfloat16": torch.bfloat16,
     "float32": torch.float32,
     "float64": torch.float64,
     "int8": torch.int8,
@@ -74,6 +76,9 @@ def _fill_cute_tensor(tensor, dtype_name, value):
 
 def _read_cute_tensor(tensor, dtype_name):
     view = _torch_view_of_cute_tensor(tensor, dtype_name)
+    if view.dtype is torch.bfloat16:
+        # NumPy has no bfloat16; hand back the exact float32 promotion instead.
+        view = view.float()
     return view.detach().cpu().numpy()
 
 


### PR DESCRIPTION
The CuTe device-side wrappers in `nvshmem4py` dispatch on the tensor's element type. Every entry point has a `cutlass.Float16` branch; none has a `cutlass.BFloat16` one, so a bf16 tensor falls off the end of the chain:

```
RuntimeError: Unsupported CuTe reduce op/dtype combination: op=sum, dtype=BFloat16
RuntimeError: Unsupported CuTe dtype for fcollect: BFloat16
RuntimeError: Unsupported CuTe dtype for RMA dispatch: BFloat16
```

(six distinct messages across the two files — the wording varies by family).

Only the Python dispatch layer is missing it. On `devel`, `nvshmem/bindings/device/cute/_cuteast.py` already declares 59 `bfloat16_*` FFI entry points against 59 `half_*` ones — a complete 1:1 set — and the sm_90 device bitcode supplies the 53 this patch reaches, which is why it links and runs with no backend change.

Each `Float16` branch is mirrored with a `BFloat16` one: 33 in `core/device/cute/collective.py` (reduce, reducescatter, fcollect, broadcast, alltoall × block/warp/thread) and 20 in `core/device/cute/rma.py` (put, get, put_signal, each ±nbi, × block/warp/thread, plus `p` and `g`). `bfloat16` is also added to the CuTe device test matrices.

A maintainer-side generator update is also needed. `cmake/generateCuteBindings.cmake` generates `collective.py` and `rma.py` from `build_assets/cute/generate_{collective,rma}.py` and `templates/core/device/cute/*.py.j2`, and that directory isn't in the repo. I patched the checked-in files and kept their generated shape — `yapf --style nvshmem4py/.style.yapf` reports the same diff before and after — but the same mirror has to go into the generator, or the next regeneration drops it.

## Validation

4×H100 over NVLink, `nvidia-cutlass-dsl 4.8.0.dev0` + `nvshmem 3.7.2`, 4 PEs on `TEAM_NODE`, all 53 branches driven through the public API. `float16` is the oracle: inputs are small integers exactly representable in both formats, varying by element index and by PE, so a correct `bfloat16` branch has to reproduce the `float16` result elementwise on every rank.

After the patch, all 53 branches run on all 4 ranks and match their `float16` control elementwise — reduce and reducescatter (sum, min, max, prod), fcollect, broadcast, alltoall, put/get ±nbi, put_signal ±nbi, `p` and `g`. The signal word comes out set on every rank in both dtypes, though the three scopes share one signal, so that part is an aggregate check. Before it, each of the 19 dispatch families raises at trace time on the first `bfloat16` branch it reaches, while its `float16` control passes.

I could not run the in-tree suite under `nvshmem4py/test/device/cute/`: its local `_compile_kernel` calls `cute.compile()` without `--link-libraries`, and ptxas then fails with `Unresolved extern function 'nvshmem_<t>_put'` for every dtype, `int32` and `float32` included. Same on cutlass-dsl 4.7.1, so not a 4.8 regression, but it does mean the `bfloat16` test parameters here are unverified on that path.